### PR TITLE
Upgrade Pixi from 6.1.2 to 6.1.3

### DIFF
--- a/src/client/package.json
+++ b/src/client/package.json
@@ -38,9 +38,9 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@pixi/unsafe-eval": "6.1.2",
+    "@pixi/unsafe-eval": "6.1.3",
     "core-js": "3.17.2",
-    "pixi.js": "6.1.2",
+    "pixi.js": "6.1.3",
     "unfetch": "^4.2.0"
   },
   "-vs-binding": {

--- a/src/client/src/game/pixi.js
+++ b/src/client/src/game/pixi.js
@@ -1,5 +1,3 @@
-import 'core-js/features/string/starts-with.js'; // Missing polyfill for IE11, https://github.com/pixijs/pixijs/issues/7775
-
 // https://pixijs.io/docs/
 // https://github.com/pixijs/pixijs/tree/dev/packages
 


### PR DESCRIPTION
Upgrade Pixi from 6.1.2 to 6.1.3
- Remove polyfill for IE for string.startsWith