### PR TITLE
strict-dynamic

### DIFF
--- a/src/client/content-security-policy.json
+++ b/src/client/content-security-policy.json
@@ -2,7 +2,7 @@
   "default-src": "'none'",
   "base-uri": "'self'",
   "object-src": "'none'",
-  "script-src": "'self'",
+  "script-src": ["'self'", "'strict-dynamic'"],
   "script-src-attr": "'none'",
   "connect-src": ["'self'", "wss://skystedt.webpubsub.azure.com", "https://dc.services.visualstudio.com"],
   "img-src": "data:",

--- a/src/client/webpack.development.mjs
+++ b/src/client/webpack.development.mjs
@@ -3,7 +3,8 @@ import sharedModern from './webpack/config/modern/shared.mjs';
 import sharedLegacy from './webpack/config/legacy/shared.mjs';
 import developmentModern, { cspProcessFn } from './webpack/config/modern/development.mjs';
 import developmentLegacy from './webpack/config/legacy/development.mjs';
-import { extendCspPluginProcessFn, mergeRules as configurationMergeRules } from './webpack/utils.mjs';
+import { mergeRules as configurationMergeRules } from './webpack/utils.mjs';
+import { extendCspPluginProcessFn } from './webpack/plugins/extended-csp-html-webpack-plugin.mjs';
 
 extendCspPluginProcessFn(sharedModern, cspProcessFn);
 

--- a/src/client/webpack/config/modern/development.mjs
+++ b/src/client/webpack/config/modern/development.mjs
@@ -54,6 +54,7 @@ export const cspProcessFn = (builtPolicy, ...parameters) => {
   // modify CSP for local development
   builtPolicy = builtPolicy
     .replace('webpack', "webpack 'allow-duplicates' webpack-dev-server#overlay")
+    .replace("'strict-dynamic'", '')
     .replace('; report-uri /api/report/csp', '') // Not allowed in <meta> tag
     .replace("; style-src-attr 'none'", "; style-src-attr 'unsafe-hashes'" + errorOverlay);
 

--- a/src/client/webpack/config/modern/shared.mjs
+++ b/src/client/webpack/config/modern/shared.mjs
@@ -17,7 +17,9 @@ import cacheGroups from '../chunks.mjs';
 import BuildInfo from '../../build-info.mjs';
 import { dir, browserslistEnvironment, mergeBabelOptions } from '../../utils.mjs';
 import postcssRemoveCarriageReturn from '../../postcss/postcss-remove-carriage-return.mjs';
+import MoveHtmlWebpackPlugin from '../../plugins/move-html-webpack-plugin.mjs';
 import ScriptsHtmlWebpackPlugin from '../../plugins/scripts-html-webpack-plugin.mjs';
+import ExtendedCspHtmlWebpackPlugin from '../../plugins/extended-csp-html-webpack-plugin.mjs';
 import ThrowOnAssetEmitedPlugin from '../../plugins/throw-on-asset-emited-plugin.mjs';
 import CreateFilePlugin from '../../plugins/create-file-plugin.mjs';
 
@@ -219,6 +221,7 @@ export default {
       template: path.resolve(dir.src, 'index.html'),
       scriptLoading: 'module'
     }),
+    new MoveHtmlWebpackPlugin(),
     new ScriptsHtmlWebpackPlugin({
       add: [
         { path: 'legacy/insights.*.js', directory: dir.dist },
@@ -238,7 +241,7 @@ export default {
       enabled: 'auto',
       hashFuncNames: ['sha384']
     }),
-    new CspHtmlWebpackPlugin(csp, {
+    new ExtendedCspHtmlWebpackPlugin(csp, {
       hashingMethod: 'sha384',
       hashEnabled: {
         'script-src': false,

--- a/src/client/webpack/plugins/extended-csp-html-webpack-plugin.mjs
+++ b/src/client/webpack/plugins/extended-csp-html-webpack-plugin.mjs
@@ -1,0 +1,31 @@
+import webpack from 'webpack';
+import CspHtmlWebpackPlugin from 'csp-html-webpack-plugin';
+
+// Override method for getShas to find precalculated hashes in integrity attributes
+export default class ExtendedCspHtmlWebpackPlugin extends CspHtmlWebpackPlugin {
+  getShas($, policyName, selector) {
+    const shas = super.getShas($, policyName, selector);
+    const integritySelector = selector.replace(/:not\((\[.+\])\)/, '$1[integrity]');
+    const integrityShas = $(integritySelector)
+      .map((_i, element) => `'${$(element).attr('integrity')}'`)
+      .get();
+    return shas.concat(integrityShas);
+  }
+}
+
+/**
+ * @param {webpack.Configuration} configuration
+ * @param {Function} processFn
+ */
+export const extendCspPluginProcessFn = (configuration, processFn) => {
+  const cspPlugin = configuration.plugins.find((plugin) => plugin.constructor.name === 'ExtendedCspHtmlWebpackPlugin');
+  if (cspPlugin) {
+    const originalProcessFn = cspPlugin.opts.processFn;
+    const options = Object.assign({}, cspPlugin.opts);
+    options.processFn = (...parameters) => {
+      originalProcessFn(...parameters);
+      processFn(...parameters);
+    };
+    cspPlugin.opts = Object.freeze(options);
+  }
+};

--- a/src/client/webpack/plugins/move-html-webpack-plugin.mjs
+++ b/src/client/webpack/plugins/move-html-webpack-plugin.mjs
@@ -1,0 +1,25 @@
+import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+
+// When using [contenthash] then webpack.optimize.RealContentHashPlugin will run
+// calculating the real hashes of the content, updating assets.
+// For HtmlWebpackPlugin to have the updated assets, it needs to be moved
+export default class MoveHtmlWebpackPlugin {
+  /** @param {webpack.Compiler} compiler */
+  apply(compiler) {
+    compiler.hooks.compilation.tap('MoveHtmlWebpackPlugin', (compilation) => {
+      compilation.hooks.processAssets.intercept({
+        register: (tap) => {
+          if (
+            tap.name === HtmlWebpackPlugin.name &&
+            tap.stage == webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE
+          ) {
+            // move HtmlWebpackPlugin to after optimize.RealContentHashPlugin is run
+            tap.stage = webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH + 1;
+          }
+          return tap;
+        }
+      });
+    });
+  }
+}

--- a/src/client/webpack/utils.mjs
+++ b/src/client/webpack/utils.mjs
@@ -30,23 +30,6 @@ export const browserslistEnvironment = (environment) => {
 };
 
 /**
- * @param {webpack.Configuration} configuration
- * @param {Function} processFn
- */
-export const extendCspPluginProcessFn = (configuration, processFn) => {
-  const cspPlugin = configuration.plugins.find((plugin) => plugin.constructor.name === 'CspHtmlWebpackPlugin');
-  if (cspPlugin) {
-    const originalProcessFn = cspPlugin.opts.processFn;
-    const options = Object.assign({}, cspPlugin.opts);
-    options.processFn = (...parameters) => {
-      originalProcessFn(...parameters);
-      processFn(...parameters);
-    };
-    cspPlugin.opts = Object.freeze(options);
-  }
-};
-
-/**
  * @typedef {import("immutability-helper").Spec<webpack.Configuration>} ImmutabilityHelperSpec
  * @param {webpack.Configuration} configuration
  * @returns {ImmutabilityHelperSpec}


### PR DESCRIPTION
- strict-dynamic with generated hashes for external sources

Firefox does not support external hashes, [https://bugzilla.mozilla.org/show_bug.cgi?id=1409200](https://bugzilla.mozilla.org/show_bug.cgi?id=1409200)